### PR TITLE
Update corne.conf to disable bluetooth 5 feature

### DIFF
--- a/config/corne.conf
+++ b/config/corne.conf
@@ -4,3 +4,8 @@
 
 # Uncomment the following line to enable the Corne OLED Display
 # CONFIG_ZMK_DISPLAY=y
+
+# troubleshooting bluetooth connectivity on windows
+# https://github.com/zmkfirmware/zmk/issues/805#issuecomment-1866956993
+# https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.2-dev1/kconfig/CONFIG_BT_CTLR_PHY_2M.html
+CONFIG_BT_CTLR_PHY_2M=n


### PR DESCRIPTION
hoping to fix an issue where corne connects to a ble (4.0) dongle on windows but sends no keystrokes.